### PR TITLE
Manually removed player collision bitmask from scene

### DIFF
--- a/levels/test_level.tscn
+++ b/levels/test_level.tscn
@@ -86,7 +86,7 @@ position = Vector2(146.23, -8)
 
 [node name="Player" parent="." node_paths=PackedStringArray("respawn_point") groups=["player"] instance=ExtResource("1_46lwt")]
 position = Vector2(211, -59)
-collision_mask = 5
+collision_mask = 9
 respawn_point = NodePath("../RespawnPoint")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Player"]
@@ -104,13 +104,9 @@ tile_set = ExtResource("10_4n8tn")
 
 [node name="WindZone" parent="." instance=ExtResource("11_wkb0e")]
 position = Vector2(952, -288)
-wind = Vector2(-10000, 0)
+wind = Vector2(-1000, 0)
 
 [node name="Collision" parent="WindZone" index="0"]
 polygon = PackedVector2Array(200, -216, -312, -288, -648, -288, -632, -216, -512, -208, -512, 8, 200, 32)
-
-[node name="WindZone2" parent="." instance=ExtResource("11_wkb0e")]
-position = Vector2(656, -192)
-wind = Vector2(-3000, 0)
 
 [editable path="WindZone"]


### PR DESCRIPTION
Now the player's collision and mask should revert back to whatever is in the player scene. I also removed that stupid little extra wind zone and slowed down the main wind zone to make it less annoying.